### PR TITLE
Lower window level

### DIFF
--- a/AlfredExtraPane/Pane.swift
+++ b/AlfredExtraPane/Pane.swift
@@ -150,7 +150,7 @@ func makeWindow() -> NSWindow {
     screen: NSScreen.main!
   )
   window.backgroundColor = .clear
-  window.level = .screenSaver
+  window.level = .modalPanel
   window.collectionBehavior = [
     .moveToActiveSpace, .stationary, .fullScreenAuxiliary
   ]


### PR DESCRIPTION
Lowering the window level makes the regular quicklook preview usable when the pane is enabled.
Are there reasons to keep a higher window level that I'm overlooking? 

Compare: 
<img width="943" alt="Screenshot 2024-10-20 at 22 01 43" src="https://github.com/user-attachments/assets/92cf0e31-1c33-4ec4-b39c-9a92da1139fc">

vs. 

<img width="949" alt="Screenshot 2024-10-20 at 21 59 50" src="https://github.com/user-attachments/assets/cff49f9a-c3d7-40ed-84f9-8954ccd84b81">
